### PR TITLE
📝 Use idiomatic Makefile command in the the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bin/pretty-make:
 .PHONY: help
 ## List available commands
 help: bin/pretty-make
-	@bin/pretty-make Makefile
+	@$< $(firstword $(MAKEFILE_LIST)
 ```
 
 ### System-wide using cargo
@@ -32,7 +32,7 @@ Then you can use Pretty Make in your Makefile like this:
 .PHONY: help
 ## List available commands
 help:
-  @pretty-make Makefile
+	@pretty-make $(firstword $(MAKEFILE_LIST)
 ```
 
 ## ⌨️ Usage


### PR DESCRIPTION
This turns the call to `pretty-make` in the README into a more idiomatic
Makefile command.

It also has the advantage to allow for arbitrary Makefile name (it get
the Makefile path from the Makefile directly). And avoid duplication of
`bin/pretty-make`, making it more easily changeable.

This may or may not be wanted. While it is more idiomatic and more flexible, it also way less readable ¯\\\_(ツ)\_/¯