### PR TITLE
✨ Allow to configure the install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ help: bin/pretty-make
 	@bin/pretty-make pretty-help Makefile
 ```
 
+The installation path (default to `bin`) can also be configured with the `INSTALL_PATH` environment variable.
+
+Example to install in `.bin` instead of `bin`:
+
+```
+.bin/pretty-make:
+	@export INSTALL_PATH=.bin
+	curl -Ls https://raw.githubusercontent.com/awea/pretty-make/master/scripts/install.sh | bash -s
+```
+
 ### System-wide using cargo
 First you have to install Pretty Make using the following command:
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 
-mkdir -p bin
+install_path="${INSTALL_PATH:-bin}"
+
+mkdir -p $install_path
 
 if [ "$(uname)" == "Darwin" ] && [ "$(uname -p)" == "arm" ]; then
-  curl -L https://github.com/Awea/pretty-make/releases/latest/download/pretty-make-macos-arm -o bin/pretty-make
-  # See: https://github.com/Awea/pretty-make/issues/17#issuecomment-1252713764
-  xattr -d com.apple.quarantine bin/pretty-make
+	curl -L https://github.com/Awea/pretty-make/releases/latest/download/pretty-make-macos-arm -o "${install_path}/pretty-make"
+	# See: https://github.com/Awea/pretty-make/issues/17#issuecomment-1252713764
+	xattr -d com.apple.quarantine "${install_path}/pretty-make"
 elif [ "$(uname)" == "Darwin" ]; then
-  curl -L https://github.com/Awea/pretty-make/releases/latest/download/pretty-make-macos -o bin/pretty-make
+	curl -L https://github.com/Awea/pretty-make/releases/latest/download/pretty-make-macos -o "${install_path}/pretty-make"
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  curl -L https://github.com/Awea/pretty-make/releases/latest/download/pretty-make-linux -o bin/pretty-make
+	curl -L https://github.com/Awea/pretty-make/releases/latest/download/pretty-make-linux -o "${install_path}/pretty-make"
 fi
 
-chmod 755 bin/pretty-make
+chmod 755 "${install_path}/pretty-make"


### PR DESCRIPTION
I have multiple projects that use `.bin` and not `bin`.

```
.bin/pretty-make:
	export INSTALL_PATH=.bin
	@curl -Ls https://raw.githubusercontent.com/awea/pretty-make/master/scripts/install.sh | bash -s
```